### PR TITLE
Improve energy efficiency by applying Reduce Size Energy Pattern

### DIFF
--- a/tourcount/src/main/java/com/wmstein/tourcount/RetrieveAddr.java
+++ b/tourcount/src/main/java/com/wmstein/tourcount/RetrieveAddr.java
@@ -16,6 +16,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.zip.GZIPInputStream;
 
 import static android.content.ContentValues.TAG;
 
@@ -45,6 +46,7 @@ public class RetrieveAddr extends AsyncTask<URL, Void, String>
         {
             //HttpsURLConnection urlConnection = (HttpsURLConnection) url.openConnection(); // https-version?
             HttpURLConnection urlConnection = (HttpURLConnection) url.openConnection();
+            urlConnection.setRequestProperty("Accept-Encoding", "gzip");
             urlConnection.setReadTimeout(10000);
             urlConnection.setConnectTimeout(15000);
             urlConnection.setRequestMethod("GET");
@@ -58,7 +60,12 @@ public class RetrieveAddr extends AsyncTask<URL, Void, String>
             }
 
             // get the XML from input stream
-            InputStream iStream = urlConnection.getInputStream();
+            InputStream iStream;
+            if ("gzip".equals(urlConnection.getContentEncoding())) {
+                iStream = new GZIPInputStream(urlConnection.getInputStream());
+            } else {
+                iStream = urlConnection.getInputStream();
+            }
 
             xmlString = convertStreamToString(iStream);
             if (MyDebug.LOG)


### PR DESCRIPTION
This improves the energy efficiency of TourCount by applying the Reduce Size Energy Pattern for mobile applications.
The energy pattern was applied in RetrieveAddr.java. The general idea is when receiving data from an URLConnection or subclasses, if possible, receive the data compressed by GZIP scheme. In this specific case, when receiving data from the urlConnection variable, request for the data to be compressed. 